### PR TITLE
Add `--compact` flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
         run: php artisan migrate --force
 
       - name: Run tests
-        run: php artisan test
+        run: php artisan test --compact


### PR DESCRIPTION
The `compact` flag allows for a smaller output that will only display failures and prevents bloat from listing every passing test on its own line.
