### PR TITLE
Add Envoyer workflow

### DIFF
--- a/.github/workflows/envoyer.yml
+++ b/.github/workflows/envoyer.yml
@@ -1,0 +1,24 @@
+name: envoyer
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+    secrets:
+      ENVOYER_DEPLOY_TOKEN:
+        required: true
+
+jobs:
+  envoyer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy
+        run: |
+          if [ -z "${{ inputs.branch }}" ]; then
+            curl -X GET "https://envoyer.io/deploy/${{ secrets.ENVOYER_DEPLOY_TOKEN }}"
+          else
+            curl -X GET "https://envoyer.io/deploy/${{ secrets.ENVOYER_DEPLOY_TOKEN }}?branch=${{ inputs.branch }}"
+          fi


### PR DESCRIPTION
Added `envoyer.yml` workflow to deploy using Envoyer.

```yaml
jobs:
  deploy:
    uses: Solar-Investments/.github/.github/workflows/envoyer.yml@main
    secrets:
      ENVOYER_DEPLOY_TOKEN: "${{ secrets.ENVOYER_DEPLOY_TOKEN }}"
```

You can also provide a `branch` to override what Envoyer will deploy:

```yaml
jobs:
  deploy:
    uses: Solar-Investments/.github/.github/workflows/envoyer.yml@main
    with:
        branch: 'feature/example-feature-branch'
    secrets:
      ENVOYER_DEPLOY_TOKEN: "${{ secrets.ENVOYER_DEPLOY_TOKEN }}"
```