### PR TITLE
Add `--ci` option to testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,4 @@ jobs:
         run: php artisan migrate --force
 
       - name: Run tests
-        run: php artisan test --compact
+        run: php artisan test --compact --ci


### PR DESCRIPTION
If testing code is committed with `->only()` activated on one, `php artisan test --ci` will still run all tests.

See:
- https://pestphp.com/docs/continuous-integration
- https://github.com/pestphp/pest/discussions/1128