### PR TITLE
Add `--exclude-group=no-ci` to `php artisan test`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,4 @@ jobs:
         run: php artisan migrate --force
 
       - name: Run tests
-        run: php artisan test --compact
+        run: php artisan test --compact --exclude-group=no-ci


### PR DESCRIPTION
If, for whatever reason, a test doesn't work in CI, but it works on local, we can filter it out.